### PR TITLE
Changed datatype from sbyte to short in anime-lists XML parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+# MonoDevelop metafiles
+MediaBrowser.Plugins.Anime.userprefs
+

--- a/MediaBrowser.Plugins.Anime/MediaBrowser.Plugins.Anime.csproj
+++ b/MediaBrowser.Plugins.Anime/MediaBrowser.Plugins.Anime.csproj
@@ -34,24 +34,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MediaBrowser.Common, Version=3.1.6161.23127, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MediaBrowser.Common.3.0.691\lib\portable-net45+win8+wpa81\MediaBrowser.Common.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="MediaBrowser.Controller, Version=3.1.6161.23125, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MediaBrowser.Server.Core.3.0.691\lib\net45\MediaBrowser.Controller.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="MediaBrowser.Model, Version=3.1.6161.23126, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MediaBrowser.Common.3.0.691\lib\portable-net45+win8+wpa81\MediaBrowser.Model.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="MediaBrowser.Common">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.692\lib\portable-net45+win8+wpa81\MediaBrowser.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="MediaBrowser.Model">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.692\lib\portable-net45+win8+wpa81\MediaBrowser.Model.dll</HintPath>
+    </Reference>
+    <Reference Include="MediaBrowser.Controller">
+      <HintPath>..\packages\MediaBrowser.Server.Core.3.0.692\lib\net45\MediaBrowser.Controller.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="anime-lists-net\AnidbEpisode.cs" />

--- a/MediaBrowser.Plugins.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/MediaBrowser.Plugins.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -270,7 +270,7 @@ namespace MediaBrowser.Plugins.Anime.Providers.AniDB.Metadata
                                 switch (episodeSubtree.Name)
                                 {
                                     case "epno":
-                                        var epno = episodeSubtree.ReadElementContentAsString();
+                                        //var epno = episodeSubtree.ReadElementContentAsString();
                                         //EpisodeInfo info = new EpisodeInfo();
                                         //info.AnimeSeriesIndex = series.AnimeSeriesIndex;
                                         //info.IndexNumberEnd = string(epno);

--- a/MediaBrowser.Plugins.Anime/anime-lists-net/AnimelistAnime.cs
+++ b/MediaBrowser.Plugins.Anime/anime-lists-net/AnimelistAnime.cs
@@ -44,7 +44,7 @@ namespace AnimeLists
 
         /// <remarks />
         [XmlAttribute("episodeoffset")]
-        public byte EpisodeOffset { get; set; }
+        public short EpisodeOffset { get; set; }
 
         /// <remarks />
         [XmlIgnore]

--- a/MediaBrowser.Plugins.Anime/anime-lists-net/AnimelistMapping.cs
+++ b/MediaBrowser.Plugins.Anime/anime-lists-net/AnimelistMapping.cs
@@ -17,7 +17,7 @@ namespace AnimeLists
 
         /// <remarks />
         [XmlAttribute("start")]
-        public byte Start { get; set; }
+        public short Start { get; set; }
 
         /// <remarks />
         [XmlIgnore]
@@ -25,7 +25,7 @@ namespace AnimeLists
 
         /// <remarks />
         [XmlAttribute("end")]
-        public byte End { get; set; }
+        public short End { get; set; }
 
         /// <remarks />
         [XmlIgnore]
@@ -33,7 +33,7 @@ namespace AnimeLists
 
         /// <remarks />
         [XmlAttribute("offset")]
-        public sbyte Offset { get; set; }
+        public short Offset { get; set; }
 
         /// <remarks />
         [XmlIgnore]

--- a/MediaBrowser.Plugins.Anime/packages.config
+++ b/MediaBrowser.Plugins.Anime/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MediaBrowser.Common" version="3.0.691" targetFramework="net45" />
-  <package id="MediaBrowser.Server.Core" version="3.0.691" targetFramework="net45" />
+  <package id="MediaBrowser.Common" version="3.0.692" targetFramework="net45" />
+  <package id="MediaBrowser.Server.Core" version="3.0.692" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This prevents overflow errors with some new animes having a offset greater than -127
