### PR TITLE
fix error if genre is null

### DIFF
--- a/MediaBrowser.Plugins.Anime/Providers/AniList/AniListSeriesProvider.cs
+++ b/MediaBrowser.Plugins.Anime/Providers/AniList/AniListSeriesProvider.cs
@@ -119,6 +119,7 @@ namespace MediaBrowser.Plugins.Anime.Providers.AniList
                 if (anime.genres != null)
                 {
                     foreach (var genre in anime.genres)
+                    if(!string.IsNullOrEmpty(genre))
                         result.Item.AddGenre(genre);
 
                     GenreHelper.CleanupGenres(result.Item);


### PR DESCRIPTION
```
2017-10-05 01:41:17.781 Error App: Error in AniList
	*** Error Report ***
	Version: 3.2.33.0
	//skip command line
	Operating system: Microsoft Windows NT 6.2.9200.0
	64-Bit OS: True
	64-Bit Process: True
	User Interactive: True
	Processor count: 4
	//skip program path
	//skip Application directory
        //eng: The value can not be NULL.
	System.ArgumentNullException: Der Wert darf nicht NULL sein.
	Parametername: name
	   bei MediaBrowser.Controller.Entities.BaseItem.AddGenre(String name)
	   bei MediaBrowser.Plugins.Anime.Providers.AniList.AniListSeriesProvider.<GetMetadata>d__11.MoveNext()
	--- Ende der Stapelüberwachung vom vorhergehenden Ort, an dem die Ausnahme ausgelöst wurde ---
	   bei System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
	   bei System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
	   bei MediaBrowser.Providers.Manager.MetadataService`2.<ExecuteRemoteProviders>d__26.MoveNext()
	System.ArgumentNullException
	   bei MediaBrowser.Controller.Entities.BaseItem.AddGenre(String name)
	   bei MediaBrowser.Plugins.Anime.Providers.AniList.AniListSeriesProvider.<GetMetadata>d__11.MoveNext()
	--- Ende der Stapelüberwachung vom vorhergehenden Ort, an dem die Ausnahme ausgelöst wurde ---
	   bei System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
	   bei System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
	   bei MediaBrowser.Providers.Manager.MetadataService`2.<ExecuteRemoteProviders>d__26.MoveNext()
```
	