### PR TITLE
Fix: Regression on Parsing Series's XML Data

### DIFF
--- a/MediaBrowser.Plugins.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/MediaBrowser.Plugins.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -673,7 +673,8 @@ namespace MediaBrowser.Plugins.Anime.Providers.AniDB.Metadata
             await RequestLimiter.Tick(cancellationToken);
             await Task.Run(() => Thread.Sleep(Plugin.Instance.Configuration.AniDB_wait_time));
             using (var stream = await httpClient.Get(requestOptions).ConfigureAwait(false))
-            using (var reader = new StreamReader(stream, Encoding.UTF8, true))
+            using (var unzipped = new GZipStream(stream, CompressionMode.Decompress))
+            using (var reader = new StreamReader(unzipped, Encoding.UTF8, true))
             using (var file = File.Open(seriesDataPath, FileMode.Create, FileAccess.Write))
             using (var writer = new StreamWriter(file))
             {


### PR DESCRIPTION
Series's XML data is gzipped and has to be decompress first. Reverting a small change.